### PR TITLE
Feat: Add translate to language feature

### DIFF
--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -79,7 +79,7 @@ export async function execUnrecognized(args: string[]): Promise<string> {
 /**
  * This function parses a command param from args, for example:
  *
- * > parseCommandModifier('!to', false, ['some', 'text', '!to', 'de'])
+ * > parseCommandModifier('to', false, ['some', 'text', '!to', 'de'])
  * { modifier: 'de', restArgs: ['some', 'text'] }
  *
  */
@@ -123,13 +123,22 @@ export async function execTranslate(
   args: string[],
   commandsParams: CommandsParams,
 ): Promise<string> {
-  const text = args.join(' ');
-  let translation;
+  let toLang: string;
+  let text: string;
 
+  const { param: toLangParam, restArgs } = parseCommandParam('to', false, args);
+  if (typeof toLangParam === 'string') {
+    toLang = toLangParam;
+    text = restArgs.join(' ');
+  } else {
+    toLang = 'en';
+    text = args.join(' ');
+  }
+
+  let translation;
   try {
-    [translation] = await translateText(text, 'en', {
-      apiKey: commandsParams.translationApiKey,
-    });
+    const apiKey = commandsParams.translationApiKey;
+    [translation] = await translateText(text, toLang, { apiKey });
   } catch (error) {
     console.error('Error while translating:', { error });
     return 'Oops... something went wrong while translating 😅 sorry, try again later';

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -76,6 +76,49 @@ export async function execUnrecognized(args: string[]): Promise<string> {
   return `Hm... "${args.join(' ')}" not sure what it means, can we maybe start over with !hi 😉`;
 }
 
+/**
+ * This function parses a command param from args, for example:
+ *
+ * > parseCommandModifier('!to', false, ['some', 'text', '!to', 'de'])
+ * { modifier: 'de', restArgs: ['some', 'text'] }
+ *
+ */
+export function parseCommandParam(
+  name: string,
+  flag: boolean,
+  args: string[],
+): {
+  param: string | boolean | null;
+  restArgs: string[];
+} {
+  let modifier: string | boolean | null = null;
+  const restArgs: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (modifier === null) {
+      if (arg === `!${name}`) {
+        if (flag) {
+          modifier = true;
+        } else if (!flag && args[index + 1]) {
+          // inc the index to avoid including the value to the restArgs
+          index += 1;
+          modifier = args[index];
+        } else {
+          restArgs.push(arg);
+        }
+      } else {
+        restArgs.push(arg);
+      }
+    } else {
+      restArgs.push(arg);
+    }
+  }
+
+  return { param: modifier, restArgs };
+}
+
 export async function execTranslate(
   args: string[],
   commandsParams: CommandsParams,

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -69,7 +69,7 @@ export function parseBotCommand(text: string): BotCommand {
 }
 
 export async function execWelcome(name: string): Promise<string> {
-  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 Just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧You can also text something like "!translate some text !to de" to translate it to German 🇩🇪`;
+  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 Just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧You can also tex me something like "!translate some text !to de" to translate it to German 🇩🇪`;
 }
 
 export async function execUnrecognized(args: string[]): Promise<string> {

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -79,8 +79,8 @@ export async function execUnrecognized(args: string[]): Promise<string> {
 /**
  * This function parses a command param from args, for example:
  *
- * > parseCommandModifier('to', false, ['some', 'text', '!to', 'de'])
- * { modifier: 'de', restArgs: ['some', 'text'] }
+ * > parseCommandParam('to', false, ['some', 'text', '!to', 'de'])
+ * { param: 'de', restArgs: ['some', 'text'] }
  *
  */
 export function parseCommandParam(
@@ -139,8 +139,8 @@ export async function execTranslate(
   try {
     const apiKey = commandsParams.translationApiKey;
     [translation] = await translateText(text, toLang, { apiKey });
-  } catch (error) {
-    console.error('Error while translating:', { error });
+  } catch (error: any) {
+    console.error('Error while translating:', error.message ?? error);
     return 'Oops... something went wrong while translating 😅 sorry, try again later';
   }
 

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -69,7 +69,7 @@ export function parseBotCommand(text: string): BotCommand {
 }
 
 export async function execWelcome(name: string): Promise<string> {
-  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 Just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧You can also tex me something like "!translate some text !to de" to translate it to German 🇩🇪`;
+  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 Just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧  You can also text me something like "!translate some text !to de" to translate it to German 🇩🇪`;
 }
 
 export async function execUnrecognized(args: string[]): Promise<string> {

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -69,7 +69,7 @@ export function parseBotCommand(text: string): BotCommand {
 }
 
 export async function execWelcome(name: string): Promise<string> {
-  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧`;
+  return `Hey ${name}, I'm a translator bot and I can help you to learn languages 📚 Just drop me a message like "!translate katzen sind super" to get it translated into English 🇬🇧You can also text something like "!translate some text !to de" to translate it to German 🇩🇪`;
 }
 
 export async function execUnrecognized(args: string[]): Promise<string> {

--- a/workers/translator-bot/src/bot-command.ts
+++ b/workers/translator-bot/src/bot-command.ts
@@ -81,9 +81,16 @@ export async function execTranslate(
   commandsParams: CommandsParams,
 ): Promise<string> {
   const text = args.join(' ');
-  const [translation] = await translateText(text, 'en', {
-    apiKey: commandsParams.translationApiKey,
-  });
+  let translation;
+
+  try {
+    [translation] = await translateText(text, 'en', {
+      apiKey: commandsParams.translationApiKey,
+    });
+  } catch (error) {
+    console.error('Error while translating:', { error });
+    return 'Oops... something went wrong while translating 😅 sorry, try again later';
+  }
 
   if (translation) {
     return `"${translation.text}" means "${translation.translatedText}" in "${translation.fromLang}" 💡`;

--- a/workers/translator-bot/test/bot-command.spec.ts
+++ b/workers/translator-bot/test/bot-command.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { execMessageCommand, stripCommandSpaces } from '../src/bot-command';
 import { translateText } from 'translator';
 
@@ -13,6 +13,10 @@ const commandsParams = {
 vi.mock('translator');
 
 describe('bot-command#execMessageCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   it('should welcome when the message is "!hi"', async () => {
     const replyText = await execMessageCommand('!hi', user, commandsParams);
     expect(replyText).toMatch(/^Hey test-user123, I'm a translator bot/);
@@ -44,6 +48,13 @@ describe('bot-command#execMessageCommand', () => {
   it('should put it straight when there is nothing translate', async () => {
     const replyText = await execMessageCommand('!translate', user, commandsParams);
     expect(replyText).toMatch(/^There is nothing to translate/);
+  });
+
+  it('should say something when there is a translation error', async () => {
+    vi.mocked(translateText).mockRejectedValueOnce(new Error('Cannot translate'));
+
+    const replyText = await execMessageCommand('!translate katzen', user, commandsParams);
+    expect(replyText).toMatch(/Oops... something went wrong while translating/);
   });
 });
 

--- a/workers/translator-bot/test/bot-command.spec.ts
+++ b/workers/translator-bot/test/bot-command.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { execMessageCommand, stripCommandSpaces } from '../src/bot-command';
+import { execMessageCommand, stripCommandSpaces, parseCommandParam } from '../src/bot-command';
 import { translateText } from 'translator';
 
 const user = {
@@ -72,5 +72,42 @@ describe('bot-command#stripCommandSpaces', () => {
   it('should do nothing when there are no spaces', () => {
     const stripped = stripCommandSpaces('!translate some text');
     expect(stripped).toBe('!translate some text');
+  });
+});
+
+describe('bot-command#parseCommandParam', () => {
+  it('should return null for a flag where the input is an empty array', () => {
+    const parsed = parseCommandParam('nolinks', true, []);
+    expect(parsed).toEqual({ param: null, restArgs: [] });
+  });
+
+  it('should properly parse a flag param when it is there', () => {
+    const parsed = parseCommandParam('nolinks', true, ['some', 'text', '!nolinks']);
+    expect(parsed).toEqual({ param: true, restArgs: ['some', 'text'] });
+  });
+
+  it('should return null for a flag param when it is not there', () => {
+    const parsed = parseCommandParam('nolinks', true, ['some', 'text', 'nks']);
+    expect(parsed).toEqual({ param: null, restArgs: ['some', 'text', 'nks'] });
+  });
+
+  it('should return null for a non-flag where the input is an empty array', () => {
+    const parsed = parseCommandParam('to', false, []);
+    expect(parsed).toEqual({ param: null, restArgs: [] });
+  });
+
+  it('should properly parse a non-flag param when it is there', () => {
+    const parsed = parseCommandParam('to', false, ['some', 'text', '!to', 'de']);
+    expect(parsed).toEqual({ param: 'de', restArgs: ['some', 'text'] });
+  });
+
+  it.skip('should return null for a non-flag param when it is there but no value', () => {
+    const parsed = parseCommandParam('to', false, ['some', 'text', '!to']);
+    expect(parsed).toEqual({ param: null, restArgs: ['some', 'text', '!to'] });
+  });
+
+  it('should return null for a non-flag param when it is not there', () => {
+    const parsed = parseCommandParam('to', false, ['some', 'text', 'en', 'de']);
+    expect(parsed).toEqual({ param: null, restArgs: ['some', 'text', 'en', 'de'] });
   });
 });

--- a/workers/translator-bot/test/bot-command.spec.ts
+++ b/workers/translator-bot/test/bot-command.spec.ts
@@ -45,6 +45,23 @@ describe('bot-command#execMessageCommand', () => {
     expect(replyText).toMatch(/^"katzen" means "cats" in "de"/);
   });
 
+  it('should translate when it can with "to" param', async () => {
+    vi.mocked(translateText).mockResolvedValueOnce([
+      {
+        text: 'cats are wild',
+        fromLang: 'en',
+        translatedText: 'katzen sind wild',
+      },
+    ]);
+
+    const replyText = await execMessageCommand(
+      '!translate cats are wild !to de',
+      user,
+      commandsParams,
+    );
+    expect(replyText).toMatch(/^"cats are wild" means "katzen sind wild" in "en"/);
+  });
+
   it('should put it straight when there is nothing translate', async () => {
     const replyText = await execMessageCommand('!translate', user, commandsParams);
     expect(replyText).toMatch(/^There is nothing to translate/);
@@ -101,7 +118,7 @@ describe('bot-command#parseCommandParam', () => {
     expect(parsed).toEqual({ param: 'de', restArgs: ['some', 'text'] });
   });
 
-  it.skip('should return null for a non-flag param when it is there but no value', () => {
+  it('should return null for a non-flag param when it is there but no value', () => {
     const parsed = parseCommandParam('to', false, ['some', 'text', '!to']);
     expect(parsed).toEqual({ param: null, restArgs: ['some', 'text', '!to'] });
   });


### PR DESCRIPTION
This PR adds support for specifying a target language via a `!to` flag in the translate command, improves error handling, and introduces a helper for parsing command parameters.

- Updated `execTranslate` to handle dynamic target languages and translation errors  
- Added `parseCommandParam` to extract flags/parameters from command arguments  
- Expanded unit tests with scenarios for `!to` flag, error handling, and `parseCommandParam`

An example of a message with a such translate command would be:

```sh

user: !translate cats are wild !to de
bot: "cats are wild" means "katzen sind wild" in "en"
```